### PR TITLE
Updating links to quay.io

### DIFF
--- a/pages/1-generate-https.md
+++ b/pages/1-generate-https.md
@@ -255,15 +255,16 @@ expose ports 80 and 443 too. Now it's time to generate our container!
 
 
 ## The Expfactory Builder Image
-The provided [expfactory builder image](https://hub.docker.com/r/vanessa/expfactory-builder) will generate your Dockerfile, and from this file you can build your Docker image.  Versons (tags) 3.12 and up (including latest) have support for https. We don't build the image within the same container for the explicit purpose that you should keep a copy of the recipe Dockerfile at hand. The basic usage is to run the image, and you can either build, test, or list.
+The provided [expfactory builder image](https://hub.docker.com/r/quay.io/vanessa/expfactory-builder) will generate your Dockerfile, and from this file you can build your Docker image.  Versons (tags) 3.12 and up (including latest) have support for https. We don't build the image within the same container for the explicit purpose that you should keep a copy of the recipe Dockerfile at hand. The basic usage is to run the image, and you can either build, test, or list.
 
 ```bash
-$ docker run vanessa/expfactory-builder [list|build|test|test-library]
+$ docker run quay.io/vanessa/expfactory-builder [list|build|test|test-library]
 ```
 
 Generally, list will show you experiments provided by expfactory, build is used to generate your custom Dockerfile, and test is used for testing (derp). We will only be covering
 enough detail here to build container with https. If you want more detail about installation of local experiments or other customization of the Dockerfile, you should refer to the main [generate page](/generate). You might also look at how to [customize your container runtime](/generate#customize-your-container).
 
+Note that bases for expfactory were initially provided on [Docker Hub](https://hub.docker.com/r/vanessa/expfactory-builder/tags) and have moved to [Quay.io](https://quay.io/repository/vanessa/expfactory-builder?tab=tags). Dockerfiles in the repository that use the expfactory-builder are also updated. If you need a previous version, please see the tags on the original Docker Hub.
 
 ## Recipe Generation
 To generate a Dockerfile to build our custom image, we need to run expfactory in the container,
@@ -274,7 +275,7 @@ mkdir -p $HOME/my-experiment/data
 
 # notice we specify a different Dockerfile input that has https
 docker run -v $HOME/my-experiment:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build tower-of-london \
               --input build/docker/Dockerfile.https
 ```

--- a/pages/1-generate.md
+++ b/pages/1-generate.md
@@ -30,13 +30,13 @@ cd /tmp/my-experiment
 What experiments do you want in your container? Let's see the ones that are available!
 
 ```
-docker run vanessa/expfactory-builder list
+docker run quay.io/vanessa/expfactory-builder list
 ```
 
 Cool, I like `digit-span`, `spatial-span`, `test-task`, and `tower-of-london`.
 
 ```
-docker run -v $PWD:/data vanessa/expfactory-builder build digit-span spatial-span tower-of-london test-task 
+docker run -v $PWD:/data quay.io/vanessa/expfactory-builder build digit-span spatial-span tower-of-london test-task 
 ```
 
 Let's build the container from the Dockerfile! We are going to name it `expfactory/experiments`
@@ -68,20 +68,20 @@ Note that if you want to deploy a container with https, you should read our [htt
 
 ## The Expfactory Builder Image
 Both of these steps start with the expfactory builder container. 
-We've [provided an image](https://hub.docker.com/r/vanessa/expfactory-builder) that will generate a Dockerfile,
-and from it you can build your Docker image.  We don't build the image within the same 
+We've [provided an image](https://hub.docker.com/r/quay.io/vanessa/expfactory-builder) that will generate a Dockerfile, and from it you can build your Docker image.  
+Note that bases for expfactory were initially provided on [Docker Hub](https://hub.docker.com/r/vanessa/expfactory-builder/tags) and have moved to [Quay.io](https://quay.io/repository/vanessa/expfactory-builder?tab=tags). Dockerfiles in the repository that use the expfactory-builder are also updated. If you need a previous version, please see the tags on the original Docker Hub. We don't build the image within the same 
 container for the explicit purpose that you should keep a copy of the recipe
 Dockerfile at hand. The basic usage is to run the image, and you can either build, test, or list.
 
 ```
-$ docker run vanessa/expfactory-builder
+$ docker run quay.io/vanessa/expfactory-builder
 
 Usage:
 
-          docker run vanessa/expfactory-builder list
-          docker run vanessa/expfactory-builder build experiment-one experiment-two ...
-          docker run -v experiments:/scif/apps vanessa/expfactory-builder test
-          docker run -v $PWD/_library:/scif/apps vanessa/expfactory-builder test-library
+          docker run quay.io/vanessa/expfactory-builder list
+          docker run quay.io/vanessa/expfactory-builder build experiment-one experiment-two ...
+          docker run -v experiments:/scif/apps quay.io/vanessa/expfactory-builder test
+          docker run -v $PWD/_library:/scif/apps quay.io/vanessa/expfactory-builder test-library
 ```
 
 We will discuss each of these commands in more detail.
@@ -94,7 +94,7 @@ We also have some pre-generated commands in our [recipes portal](/experiments/re
 Here is how to list all the experiments in the library:
 
 ```
-docker run vanessa/expfactory-builder list
+docker run quay.io/vanessa/expfactory-builder list
 
 Expfactory Version: 3.0
 Experiments
@@ -110,7 +110,7 @@ Experiments
 Try using grep if you want to search for a term in the name or url
 
 ```
-docker run vanessa/expfactory-builder list | grep survey
+docker run quay.io/vanessa/expfactory-builder list | grep survey
 2  alcohol-drugs-survey	https://www.github.com/expfactory-experiments/alcohol-drugs-survey
 4  dospert-eb-survey	https://www.github.com/expfactory-experiments/dospert-eb-survey
 5  dospert-rp-survey	https://www.github.com/expfactory-experiments/dospert-rp-survey
@@ -135,7 +135,7 @@ should not already contain a Dockerfile, and we recommend that you set this fold
 ```
 mkdir -p /tmp/my-experiment/data
 docker run -v /tmp/my-experiment:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build tower-of-london
 
 Expfactory Version: 3.0
@@ -157,7 +157,7 @@ I would then mount the present working directory (`experiments`) to `/data` in t
 
 ```
 docker run -v $PWD:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build test-task \
                     /data/test-task-two
 
@@ -202,7 +202,7 @@ The library install (top) clones from Github, and the local install adds the ent
 
 ```
 docker run -v /tmp/another_base:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build test-task /data/test-task-two
 ```
 
@@ -453,7 +453,7 @@ You can also use the name.
 
 
 ## Adding Experiments
-While we encourage you to re-generate the file with the `vanessa/expfactory-builder` so generation of your
+While we encourage you to re-generate the file with the `quay.io/vanessa/expfactory-builder` so generation of your
 container is reproducible, it's possible to install experiments into your container after it's generated. You
 should only do this for development, as changes that you make to your container that are not recorded in the Dockerfile
 are not reproducible. Let's say that we have an experiment container that has one task, `tower-of-london`, and we want to install
@@ -525,7 +525,7 @@ docker restart 9e256e1b1473
 You then should have the new experiment installed in the container! Remember, you would want to go back and (properly) produce this:
 
 ```
-docker run -v $PWD:/data vanessa/expfactory-builder build digit-span test-task 
+docker run -v $PWD:/data quay.io/vanessa/expfactory-builder build digit-span test-task 
 ```
 
 If you have any questions about the above, or want more detail, please [get in touch](https://www.github.com/expfactory/issues) as I am looking to develop this.

--- a/pages/2-customize.md
+++ b/pages/2-customize.md
@@ -19,14 +19,14 @@ If you leave these defaults, you (and the future users of your container) can th
 The choice is up to you! For settings defaults at build time, see the next section [default variables](#default-variables). For setting at runtime, see the next page for [starting your container](/usage.html#start-the-container).
  
 ## Default Variables
-When you run a build with `vanessa/expfactory-builder` image, there are other command line options available pertaining to the database and study id. Try running `docker run vanessa/expfactory-builder build --help` to see usage. If you customize these variables, the container recipe generated will follow suit.
+When you run a build with `quay.io/vanessa/expfactory-builder` image, there are other command line options available pertaining to the database and study id. Try running `docker run quay.io/vanessa/expfactory-builder build --help` to see usage. If you customize these variables, the container recipe generated will follow suit.
 
 ### database
 We recommend that you generate your container using the default "filesystem" database, and customize the database at runtime. A **filesystem** database is flat files, meaning that results are written to a mapped folder on the local machine, and each participant has their own results folder. This option is provided as many labs are accustomed to providing a battery locally, and want to save output directly to the filesystem without having any expertise with setting up a database. This argument doesn't need to be specified, and would coincide with:
 
 ```
 docker run -v /tmp/my-experiment:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build --database filesystem \
                       tower-of-london
 ```
@@ -58,7 +58,7 @@ To ask for a different study id:
 
 ```
 docker run -v /tmp/my-experiment:/data \
-              vanessa/expfactory-builder \
+              quay.io/vanessa/expfactory-builder \
               build --studyid dns \
                       tower-of-london
 ```
@@ -101,6 +101,8 @@ The next set are relevant for installation.
 | EXPFACTORY_LOGS | /scif/logs | NA | folder to store `expfactory.log` in |
 | EXPFACTORY_COLORIZE | true | NA | print colored debugging to the screen |
 | EXPFACTORY_SERVER | localhost | NA | the server address, usually localhost is appropriate |
+
+Note that bases for expfactory were initially provided on [Docker Hub](https://hub.docker.com/r/vanessa/expfactory-builder/tags) and have moved to [Quay.io](https://quay.io/repository/vanessa/expfactory-builder?tab=tags). Dockerfiles in the repository that use the expfactory-builder are also updated. If you need a previous version, please see the tags on the original Docker Hub.
 
 ## Expfactory wants Your Feedback!
 The customization process is very important, because it will mean allowing you to select variable stimuli, lengths, or anything to make a likely general experiment specific to your use case. To help with this, please [let us know](https://www.github.com/expfactory/expfactory/issues) your thoughts.

--- a/pages/5-contribute.md
+++ b/pages/5-contribute.md
@@ -155,7 +155,8 @@ we just talked about above. This test is appropriate if you've prepared an exper
  - a **contribution** is a submission of one or more experiments to the [library](https://www.github.com/expfactory/experiments),  meaning one or more markdown file intended to be added to the `_library` folder. The contribution tests also test the experiments, but retrieves them from your repository on Github. Thus, this test is useful when you've pushed your experiment to Github, and want to (locally) test if it's ready for the library.
  - an **install** means that you've finished your experiment, and want to see it running in the experiments container.
 
-For the cases above, you can use the `vanessa/expfactory-builder` image to run tests. It assumes mounting either a directory with one or more experiment subfolders
+For the cases above, you can use the `quay.io/vanessa/expfactory-builder` image to run tests. It assumes mounting either a directory with one or more experiment subfolders. 
+Note that bases for expfactory were initially provided on [Docker Hub](https://hub.docker.com/r/vanessa/expfactory-builder/tags) and have moved to [Quay.io](https://quay.io/repository/vanessa/expfactory-builder?tab=tags). Dockerfiles in the repository that use the expfactory-builder are also updated. If you need a previous version, please see the tags on the original Docker Hub.
 
 
 ### Test an Experiment
@@ -165,7 +166,7 @@ Testing an experiment primarily means two things: some kind of static testing fo
 When you submit an experiment for review, given that the repository for the experiment is also hosting it on the Github pages associated with the repository, it's likely easy enough for you and your reviewers to test the experiment using Github pages. However, for predictable experiment layouts (e.g., jspsych) we have developed a set of [Experiment Robots](/integrations.html#expfactory-robots) that you can use for hands off interactive testing.
 
 ### Static Testing
-You have two options to test experiments on your host using `vanessa/expfactory-builder`. If you want to test a single experiment, meaning a folder with a `config.json` file:
+You have two options to test experiments on your host using `quay.io/vanessa/expfactory-builder`. If you want to test a single experiment, meaning a folder with a `config.json` file:
 
 ```
 my-experiment/
@@ -175,7 +176,7 @@ my-experiment/
 then you should bind directory to it like this:
 
 ```
-docker run -v my-experiment:/scif/apps vanessa/expfactory-builder test
+docker run -v my-experiment:/scif/apps quay.io/vanessa/expfactory-builder test
 Testing experiments mounted to /scif/apps
 ....Test: Experiment Validation
 
@@ -201,7 +202,7 @@ experiments/
 then you can bind the the main top level folder like this:
 
 ```
-docker run -v experiments:/scif/apps vanessa/expfactory-builder test
+docker run -v experiments:/scif/apps quay.io/vanessa/expfactory-builder test
 Testing experiments mounted to /scif/apps
 .
 ----------------------------------------------------------------------
@@ -234,7 +235,7 @@ This set of tests is more stringent in that the test starts with one of more sub
 You need to bind the folder with markdown files for the library to `/scif/data` this time around. These tests have a lot more output because they are more substantial:
 
 ```
-docker run -v $PWD/_library:/scif/data vanessa/expfactory-builder test-library
+docker run -v $PWD/_library:/scif/data quay.io/vanessa/expfactory-builder test-library
 ```
 
 
@@ -243,7 +244,7 @@ Testing an installation is likely the most important, and final step. We mimic t
 
 ```
 mydir -p /tmp/recipe
-docker run -v /tmp/recipe:/data vanessa/expfactory-builder build test-task
+docker run -v /tmp/recipe:/data quay.io/vanessa/expfactory-builder build test-task
 ```
 
 then build your container


### PR DESCRIPTION
This pull request will update container references to use quay.io. Note that Docker Hub still does not provide repo/permission specific tokens, so we are switching to use quay.

Signed-off-by: vsoch <vsochat@stanford.edu>